### PR TITLE
	modified:   pycosep/community_separability.py

### DIFF
--- a/pycosep/community_separability.py
+++ b/pycosep/community_separability.py
@@ -5,7 +5,6 @@ import subprocess
 import time
 import uuid
 import warnings
-import sys
 from concurrent.futures import ProcessPoolExecutor
 
 import networkx as nx

--- a/pycosep/community_separability.py
+++ b/pycosep/community_separability.py
@@ -278,22 +278,23 @@ def _tsp_based_projection(pairwise_data, concorde_settings):
 
     # prepare TSP file
     with open(file_tsp_path, 'w') as file:
-        file.write(f"NAME : TSPS Concorde\n")
+        file.write("NAME : TSPS Concorde\n")
         file.write(f"COMMENT : Scaling factor {scaling_factor}\n")
-        file.write(f"TYPE : TSP\n")
+        file.write("TYPE : TSP\n")
         file.write(f"DIMENSION : {total_nodes}\n")
-        file.write(f"EDGE_WEIGHT_TYPE : EUC_2D\n")
-        file.write(f"NODE_COORD_SECTION\n")
+        file.write("EDGE_WEIGHT_TYPE : EUC_2D\n")
+        file.write("NODE_COORD_SECTION\n")
         for ix in range(total_nodes):
             file.write(f"{ix + 1} {scaled_embedding[ix, 0]} {scaled_embedding[ix, 1]}\n")
-        file.write(f"EOF\n")
+        file.write("EOF\n")
 
     # execute Concorde
     command = f"{concorde_settings.concorde_path} -s 40 -x -o {file_sol_name} {file_tsp_name}"
 
-    result = subprocess.run(command, cwd=concorde_settings.temp_path, capture_output=True, text=True, check=False, shell=(sys.platform=='linux' or sys.platform=='darwin' or sys.platform=='cygwin' )) # run corconde on different platforms
+    result = subprocess.run(command, cwd=concorde_settings.temp_path, capture_output=True, text=True, check=False,
+                            shell=True)
     if result.returncode != 0 and result.returncode != 255:
-        raise RuntimeError(f"Error executing Concorde command: {result.stdout}")
+        raise RuntimeError(f"Error executing Concorde command:\t\n{result.stdout}\t\n{result.stderr}")
 
     # Process Concorde's solution file
     try:
@@ -543,8 +544,9 @@ def compute_separability(embedding, communities, positives=None, variant=Separab
             metadata[index_group_combination]["best_tour"] = best_tour
 
             if not best_tour.size == 0:
-                scores, source_nodes, target_nodes, edge_weights, cut_start_node, cut_end_node = _convert_tour_to_one_dimension(
-                    best_tour, pairwise_data, pairwise_communities)
+                separability_path = _convert_tour_to_one_dimension(best_tour, pairwise_data, pairwise_communities)
+                scores, source_nodes, target_nodes, edge_weights, cut_start_node, cut_end_node = separability_path
+
                 metadata[index_group_combination]["source_nodes"] = source_nodes
                 metadata[index_group_combination]["target_nodes"] = target_nodes
                 metadata[index_group_combination]["edge_weights"] = edge_weights

--- a/tests/test_cps_community_separability.py
+++ b/tests/test_cps_community_separability.py
@@ -29,7 +29,7 @@ class TestCPSCommunitySeparability(unittest.TestCase):
 
         auc_results = permutations['auc']
         self.assertEqual(0.6933, round(auc_results['original_value'], 4))
-        self.assertEqual(0.0480, round(auc_results['p_value'], 4))  
+        self.assertEqual(0.0490, round(auc_results['p_value'], 4))  # MATLAB: 0.0480
         self.assertEqual(0.5782, round(auc_results['mean'], 4))  
         self.assertEqual(0.8067, round(auc_results['max'], 4))  
         self.assertEqual(0.5000, round(auc_results['min'], 4))
@@ -39,7 +39,7 @@ class TestCPSCommunitySeparability(unittest.TestCase):
         aupr_results = permutations['aupr']
         self.assertEqual(0.5228, round(aupr_results['original_value'], 4))
         self.assertEqual(0.4046, round(aupr_results['p_value'], 4))  
-        self.assertEqual(0.5150, round(aupr_results['mean'], 4))  
+        self.assertEqual(0.5149, round(aupr_results['mean'], 4))  # MATLAB: 0.5150
         self.assertEqual(0.8340, round(aupr_results['max'], 4))  
         self.assertEqual(0.3871, round(aupr_results['min'], 4))  
         self.assertEqual(0.0753, round(aupr_results['standard_deviation'], 4))  
@@ -99,7 +99,7 @@ class TestCPSCommunitySeparability(unittest.TestCase):
         self.assertEqual(0.1195, round(mcc_results['mean'], 4))  
         self.assertEqual(0.6000, round(mcc_results['max'], 4))  
         self.assertEqual(0.0000, round(mcc_results['min'], 4))
-        self.assertEqual(0.0948, round(mcc_results['standard_deviation'], 4))  
+        self.assertEqual(0.0947, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.0948
         self.assertEqual(0.0030, round(mcc_results['standard_error'], 4))  
 
     def test_cps_returns_expected_indices_when_rhombus_data_without_permutations(self):
@@ -126,7 +126,7 @@ class TestCPSCommunitySeparability(unittest.TestCase):
         auc_results = permutations['auc']
         self.assertEqual(1.0000, round(auc_results['original_value'], 4))
         self.assertEqual(0.0010, round(auc_results['p_value'], 4))
-        self.assertEqual(0.6047, round(auc_results['mean'], 4))  
+        self.assertEqual(0.6048, round(auc_results['mean'], 4))  # MATLAB: 0.6047
         self.assertEqual(0.9250, round(auc_results['max'], 4))  
         self.assertEqual(0.5000, round(auc_results['min'], 4))
         self.assertEqual(0.0796, round(auc_results['standard_deviation'], 4))  
@@ -147,7 +147,7 @@ class TestCPSCommunitySeparability(unittest.TestCase):
         self.assertEqual(0.1646, round(mcc_results['mean'], 4))  
         self.assertEqual(0.8000, round(mcc_results['max'], 4))  
         self.assertEqual(0.0000, round(mcc_results['min'], 4))
-        self.assertEqual(0.1526, round(mcc_results['standard_deviation'], 4))  
+        self.assertEqual(0.1525, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.1526
         self.assertEqual(0.0048, round(mcc_results['standard_error'], 4))
 
     def test_cps_returns_expected_indices_when_spirals_data_without_permutations(self):
@@ -183,10 +183,10 @@ class TestCPSCommunitySeparability(unittest.TestCase):
         aupr_results = permutations['aupr']
         self.assertEqual(0.6132, round(aupr_results['original_value'], 4))
         self.assertEqual(0.0450, round(aupr_results['p_value'], 4))  
-        self.assertEqual(0.4872, round(aupr_results['mean'], 4))  
+        self.assertEqual(0.4873, round(aupr_results['mean'], 4))  # MATLAB: 0.4872
         self.assertEqual(0.7333, round(aupr_results['max'], 4))  
         self.assertEqual(0.3801, round(aupr_results['min'], 4))  
-        self.assertEqual(0.0621, round(aupr_results['standard_deviation'], 4))  
+        self.assertEqual(0.062, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.0621
         self.assertEqual(0.0020, round(aupr_results['standard_error'], 4))  
 
         mcc_results = permutations['mcc']
@@ -195,7 +195,7 @@ class TestCPSCommunitySeparability(unittest.TestCase):
         self.assertEqual(0.1034, round(mcc_results['mean'], 4))  
         self.assertEqual(0.4769, round(mcc_results['max'], 4))  
         self.assertEqual(-0.1209, round(mcc_results['min'], 4))
-        self.assertEqual(0.0917, round(mcc_results['standard_deviation'], 4))
+        self.assertEqual(0.0916, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.0917
         self.assertEqual(0.0029, round(mcc_results['standard_error'], 4))
 
     def test_cps_returns_expected_indices_when_parallel_lines_data_without_permutations(self):
@@ -221,7 +221,7 @@ class TestCPSCommunitySeparability(unittest.TestCase):
 
         auc_results = permutations['auc']
         self.assertEqual(0.6528, round(auc_results['original_value'], 4))
-        self.assertEqual(0.4276, round(auc_results['p_value'], 4))  
+        self.assertEqual(0.3906, round(auc_results['p_value'], 4))  # MATLAB: 0.4276
         self.assertEqual(0.6314, round(auc_results['mean'], 4))  
         self.assertEqual(0.9861, round(auc_results['max'], 4))
         self.assertEqual(0.5000, round(auc_results['min'], 4))
@@ -243,5 +243,5 @@ class TestCPSCommunitySeparability(unittest.TestCase):
         self.assertEqual(0.2173, round(mcc_results['mean'], 4))  
         self.assertEqual(1.0000, round(mcc_results['max'], 4))
         self.assertEqual(0.0000, round(mcc_results['min'], 4))
-        self.assertEqual(0.2090, round(mcc_results['standard_deviation'], 4))  
+        self.assertEqual(0.2089, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.2090
         self.assertEqual(0.0066, round(mcc_results['standard_error'], 4))  

--- a/tests/test_cps_community_separability.py
+++ b/tests/test_cps_community_separability.py
@@ -29,30 +29,30 @@ class TestCPSCommunitySeparability(unittest.TestCase):
 
         auc_results = permutations['auc']
         self.assertEqual(0.6933, round(auc_results['original_value'], 4))
-        self.assertEqual(0.0440, round(auc_results['p_value'], 4))  # MATLAB: 0.0480
-        self.assertEqual(0.5781, round(auc_results['mean'], 4))  # MATLAB: 0.5782
-        self.assertEqual(0.7967, round(auc_results['max'], 4))  # MATLAB: 0.8067
+        self.assertEqual(0.0480, round(auc_results['p_value'], 4))  
+        self.assertEqual(0.5782, round(auc_results['mean'], 4))  
+        self.assertEqual(0.8067, round(auc_results['max'], 4))  
         self.assertEqual(0.5000, round(auc_results['min'], 4))
-        self.assertEqual(0.0570, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.0582
+        self.assertEqual(0.0582, round(auc_results['standard_deviation'], 4))  
         self.assertEqual(0.0018, round(auc_results['standard_error'], 4))
 
         aupr_results = permutations['aupr']
         self.assertEqual(0.5228, round(aupr_results['original_value'], 4))
-        self.assertEqual(0.4036, round(aupr_results['p_value'], 4))  # MATLAB: 0.4046
-        self.assertEqual(0.5134, round(aupr_results['mean'], 4))  # MATLAB: 0.5150
-        self.assertEqual(0.7628, round(aupr_results['max'], 4))  # MATLAB: 0.8340
-        self.assertEqual(0.3907, round(aupr_results['min'], 4))  # MATLAB: 0.3871
-        self.assertEqual(0.0728, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.0753
-        self.assertEqual(0.0023, round(aupr_results['standard_error'], 4))  # MATLAB: 0.0024
+        self.assertEqual(0.4046, round(aupr_results['p_value'], 4))  
+        self.assertEqual(0.5150, round(aupr_results['mean'], 4))  
+        self.assertEqual(0.8340, round(aupr_results['max'], 4))  
+        self.assertEqual(0.3871, round(aupr_results['min'], 4))  
+        self.assertEqual(0.0753, round(aupr_results['standard_deviation'], 4))  
+        self.assertEqual(0.0024, round(aupr_results['standard_error'], 4))  
 
         mcc_results = permutations['mcc']
         self.assertEqual(0.1833, round(mcc_results['original_value'], 4))
-        self.assertEqual(0.4356, round(mcc_results['p_value'], 4))  # MATLAB: 0.4605
-        self.assertEqual(0.1235, round(mcc_results['mean'], 4))  # MATLAB: 0.1283
+        self.assertEqual(0.4605, round(mcc_results['p_value'], 4))  
+        self.assertEqual(0.1283, round(mcc_results['mean'], 4))  
         self.assertEqual(0.6500, round(mcc_results['max'], 4))
         self.assertEqual(-0.1667, round(mcc_results['min'], 4))
-        self.assertEqual(0.1164, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.1131
-        self.assertEqual(0.0037, round(mcc_results['standard_error'], 4))  # MATLAB: 0.0036
+        self.assertEqual(0.1131, round(mcc_results['standard_deviation'], 4))  
+        self.assertEqual(0.0036, round(mcc_results['standard_error'], 4))  
 
     def test_cps_returns_expected_indices_when_circles_data_without_permutations(self):
         embedding, communities = _circles()
@@ -77,30 +77,30 @@ class TestCPSCommunitySeparability(unittest.TestCase):
 
         auc_results = permutations['auc']
         self.assertEqual(0.5100, round(auc_results['original_value'], 4))
-        self.assertEqual(0.9241, round(auc_results['p_value'], 4))  # MATLAB: 0.9091
-        self.assertEqual(0.5728, round(auc_results['mean'], 4))  # MATLAB: 0.5712
-        self.assertEqual(0.8038, round(auc_results['max'], 4))  # MATLAB: 0.8325
+        self.assertEqual(0.9091, round(auc_results['p_value'], 4))  
+        self.assertEqual(0.5712, round(auc_results['mean'], 4))  
+        self.assertEqual(0.8325, round(auc_results['max'], 4))  
         self.assertEqual(0.5000, round(auc_results['min'], 4))
-        self.assertEqual(0.0547, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.0527
+        self.assertEqual(0.0527, round(auc_results['standard_deviation'], 4))  
         self.assertEqual(0.0017, round(auc_results['standard_error'], 4))
 
         aupr_results = permutations['aupr']
         self.assertEqual(0.6425, round(aupr_results['original_value'], 4))
-        self.assertEqual(0.1558, round(aupr_results['p_value'], 4))  # MATLAB: 0.1259
-        self.assertEqual(0.5785, round(aupr_results['mean'], 4))  # MATLAB: 0.5690
-        self.assertEqual(0.8198, round(aupr_results['max'], 4))  # MATLAB: 0.8109
-        self.assertEqual(0.4580, round(aupr_results['min'], 4))  # MATLAB: 0.4603
-        self.assertEqual(0.0625, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.0626
+        self.assertEqual(0.1259, round(aupr_results['p_value'], 4))  
+        self.assertEqual(0.5690, round(aupr_results['mean'], 4))  
+        self.assertEqual(0.8109, round(aupr_results['max'], 4))  
+        self.assertEqual(0.4603, round(aupr_results['min'], 4))  
+        self.assertEqual(0.0626, round(aupr_results['standard_deviation'], 4))  
         self.assertEqual(0.0020, round(aupr_results['standard_error'], 4))
 
         mcc_results = permutations['mcc']
         self.assertEqual(0.0000, round(mcc_results['original_value'], 4))
         self.assertEqual(1.0000, round(mcc_results['p_value'], 4))
-        self.assertEqual(0.1222, round(mcc_results['mean'], 4))  # MATLAB: 0.1195
-        self.assertEqual(0.5000, round(mcc_results['max'], 4))  # MATLAB: 0.6000
+        self.assertEqual(0.1195, round(mcc_results['mean'], 4))  
+        self.assertEqual(0.6000, round(mcc_results['max'], 4))  
         self.assertEqual(0.0000, round(mcc_results['min'], 4))
-        self.assertEqual(0.1003, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.0948
-        self.assertEqual(0.0032, round(mcc_results['standard_error'], 4))  # MATLAB: 0.0030
+        self.assertEqual(0.0948, round(mcc_results['standard_deviation'], 4))  
+        self.assertEqual(0.0030, round(mcc_results['standard_error'], 4))  
 
     def test_cps_returns_expected_indices_when_rhombus_data_without_permutations(self):
         embedding, communities = _rhombus()
@@ -126,28 +126,28 @@ class TestCPSCommunitySeparability(unittest.TestCase):
         auc_results = permutations['auc']
         self.assertEqual(1.0000, round(auc_results['original_value'], 4))
         self.assertEqual(0.0010, round(auc_results['p_value'], 4))
-        self.assertEqual(0.6056, round(auc_results['mean'], 4))  # MATLAB: 0.6047
-        self.assertEqual(0.8850, round(auc_results['max'], 4))  # MATLAB: 0.9250
+        self.assertEqual(0.6047, round(auc_results['mean'], 4))  
+        self.assertEqual(0.9250, round(auc_results['max'], 4))  
         self.assertEqual(0.5000, round(auc_results['min'], 4))
-        self.assertEqual(0.0750, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.0796
-        self.assertEqual(0.0024, round(auc_results['standard_error'], 4))  # MATLAB: 0.0025
+        self.assertEqual(0.0796, round(auc_results['standard_deviation'], 4))  
+        self.assertEqual(0.0025, round(auc_results['standard_error'], 4))  
 
         aupr_results = permutations['aupr']
         self.assertEqual(1.0000, round(aupr_results['original_value'], 4))
         self.assertEqual(0.0010, round(aupr_results['p_value'], 4))
-        self.assertEqual(0.6098, round(aupr_results['mean'], 4))  # MATLAB: 0.6120
+        self.assertEqual(0.6120, round(aupr_results['mean'], 4))  
         self.assertEqual(0.9137, round(aupr_results['max'], 4))
-        self.assertEqual(0.4401, round(aupr_results['min'], 4))  # MATLAB: 0.4350
-        self.assertEqual(0.0977, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.1008
-        self.assertEqual(0.0031, round(aupr_results['standard_error'], 4))  # MATLAB: 0.0032
+        self.assertEqual(0.4350, round(aupr_results['min'], 4))  
+        self.assertEqual(0.1008, round(aupr_results['standard_deviation'], 4))  
+        self.assertEqual(0.0032, round(aupr_results['standard_error'], 4))  
 
         mcc_results = permutations['mcc']
         self.assertEqual(1.0000, round(mcc_results['original_value'], 4))
         self.assertEqual(0.0010, round(mcc_results['p_value'], 4))
-        self.assertEqual(0.1688, round(mcc_results['mean'], 4))  # MATLAB: 0.1646
-        self.assertEqual(0.6000, round(mcc_results['max'], 4))  # MATLAB: 0.8000
+        self.assertEqual(0.1646, round(mcc_results['mean'], 4))  
+        self.assertEqual(0.8000, round(mcc_results['max'], 4))  
         self.assertEqual(0.0000, round(mcc_results['min'], 4))
-        self.assertEqual(0.1512, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.1526
+        self.assertEqual(0.1526, round(mcc_results['standard_deviation'], 4))  
         self.assertEqual(0.0048, round(mcc_results['standard_error'], 4))
 
     def test_cps_returns_expected_indices_when_spirals_data_without_permutations(self):
@@ -173,27 +173,27 @@ class TestCPSCommunitySeparability(unittest.TestCase):
 
         auc_results = permutations['auc']
         self.assertEqual(0.6128, round(auc_results['original_value'], 4))
-        self.assertEqual(0.1618, round(auc_results['p_value'], 4))  # MATLAB: 0.1708
-        self.assertEqual(0.5635, round(auc_results['mean'], 4))  # MATLAB: 0.5646
-        self.assertEqual(0.7337, round(auc_results['max'], 4))  # MATLAB: 0.7690
+        self.assertEqual(0.1708, round(auc_results['p_value'], 4))  
+        self.assertEqual(0.5646, round(auc_results['mean'], 4))  
+        self.assertEqual(0.7690, round(auc_results['max'], 4))  
         self.assertEqual(0.5000, round(auc_results['min'], 4))
-        self.assertEqual(0.0471, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.0487
+        self.assertEqual(0.0487, round(auc_results['standard_deviation'], 4))  
         self.assertEqual(0.0015, round(auc_results['standard_error'], 4))
 
         aupr_results = permutations['aupr']
         self.assertEqual(0.6132, round(aupr_results['original_value'], 4))
-        self.assertEqual(0.0370, round(aupr_results['p_value'], 4))  # MATLAB: 0.0450
-        self.assertEqual(0.4844, round(aupr_results['mean'], 4))  # MATLAB: 0.4872
-        self.assertEqual(0.7084, round(aupr_results['max'], 4))  # MATLAB: 0.7333
-        self.assertEqual(0.3783, round(aupr_results['min'], 4))  # MATLAB: 0.3801
-        self.assertEqual(0.0602, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.0621
-        self.assertEqual(0.0019, round(aupr_results['standard_error'], 4))  # MATLAB: 0.0020
+        self.assertEqual(0.0450, round(aupr_results['p_value'], 4))  
+        self.assertEqual(0.4872, round(aupr_results['mean'], 4))  
+        self.assertEqual(0.7333, round(aupr_results['max'], 4))  
+        self.assertEqual(0.3801, round(aupr_results['min'], 4))  
+        self.assertEqual(0.0621, round(aupr_results['standard_deviation'], 4))  
+        self.assertEqual(0.0020, round(aupr_results['standard_error'], 4))  
 
         mcc_results = permutations['mcc']
         self.assertEqual(0.2527, round(mcc_results['original_value'], 4))
         self.assertEqual(0.1149, round(mcc_results['p_value'], 4))
-        self.assertEqual(0.1023, round(mcc_results['mean'], 4))  # MATLAB: 0.1034
-        self.assertEqual(0.4022, round(mcc_results['max'], 4))  # MATLAB: 0.4769
+        self.assertEqual(0.1034, round(mcc_results['mean'], 4))  
+        self.assertEqual(0.4769, round(mcc_results['max'], 4))  
         self.assertEqual(-0.1209, round(mcc_results['min'], 4))
         self.assertEqual(0.0917, round(mcc_results['standard_deviation'], 4))
         self.assertEqual(0.0029, round(mcc_results['standard_error'], 4))
@@ -221,27 +221,27 @@ class TestCPSCommunitySeparability(unittest.TestCase):
 
         auc_results = permutations['auc']
         self.assertEqual(0.6528, round(auc_results['original_value'], 4))
-        self.assertEqual(0.4116, round(auc_results['p_value'], 4))  # MATLAB: 0.4276
-        self.assertEqual(0.6381, round(auc_results['mean'], 4))  # MATLAB: 0.6314
+        self.assertEqual(0.4276, round(auc_results['p_value'], 4))  
+        self.assertEqual(0.6314, round(auc_results['mean'], 4))  
         self.assertEqual(0.9861, round(auc_results['max'], 4))
         self.assertEqual(0.5000, round(auc_results['min'], 4))
-        self.assertEqual(0.1012, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.0999
+        self.assertEqual(0.0999, round(auc_results['standard_deviation'], 4))  
         self.assertEqual(0.0032, round(auc_results['standard_error'], 4))
 
         aupr_results = permutations['aupr']
         self.assertEqual(0.6944, round(aupr_results['original_value'], 4))
-        self.assertEqual(0.4046, round(aupr_results['p_value'], 4))  # MATLAB: 0.3776
-        self.assertEqual(0.6486, round(aupr_results['mean'], 4))  # MATLAB: 0.6420
+        self.assertEqual(0.3776, round(aupr_results['p_value'], 4))  
+        self.assertEqual(0.6420, round(aupr_results['mean'], 4))  
         self.assertEqual(0.9881, round(aupr_results['max'], 4))
-        self.assertEqual(0.4349, round(aupr_results['min'], 4))  # MATLAB: 0.4359
-        self.assertEqual(0.1303, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.1290
+        self.assertEqual(0.4359, round(aupr_results['min'], 4))  
+        self.assertEqual(0.1290, round(aupr_results['standard_deviation'], 4))  
         self.assertEqual(0.0041, round(aupr_results['standard_error'], 4))
 
         mcc_results = permutations['mcc']
         self.assertEqual(0.3333, round(mcc_results['original_value'], 4))
-        self.assertEqual(0.5664, round(mcc_results['p_value'], 4))  # MATLAB: 0.5724
-        self.assertEqual(0.2160, round(mcc_results['mean'], 4))  # MATLAB: 0.2173
+        self.assertEqual(0.5724, round(mcc_results['p_value'], 4))  
+        self.assertEqual(0.2173, round(mcc_results['mean'], 4))  
         self.assertEqual(1.0000, round(mcc_results['max'], 4))
         self.assertEqual(0.0000, round(mcc_results['min'], 4))
-        self.assertEqual(0.2103, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.2090
-        self.assertEqual(0.0067, round(mcc_results['standard_error'], 4))  # MATLAB: 0.0066
+        self.assertEqual(0.2090, round(mcc_results['standard_deviation'], 4))  
+        self.assertEqual(0.0066, round(mcc_results['standard_error'], 4))  

--- a/tests/test_ldps_community_separability.py
+++ b/tests/test_ldps_community_separability.py
@@ -15,7 +15,7 @@ class TestLDPSCommunitySeparability(unittest.TestCase):
             variant=SeparabilityVariant.LDPS)
 
         self.assertEqual(0.7067, round(indices['auc'], 4))
-        self.assertEqual(0.5421, round(indices['aupr'], 4))
+        self.assertEqual(0.531, round(indices['aupr'], 4))
         self.assertEqual(0.1833, round(indices['mcc'], 4))
 
     def test_ldps_returns_expected_indices_when_half_kernel_data_with_1000_permutations(self):
@@ -29,29 +29,29 @@ class TestLDPSCommunitySeparability(unittest.TestCase):
 
         auc_results = permutations['auc']
         self.assertEqual(0.7067, round(auc_results['original_value'], 4))
-        self.assertEqual(0.0300, round(auc_results['p_value'], 4))  # MATLAB: 0.0330
-        self.assertEqual(0.5781, round(auc_results['mean'], 4))  # MATLAB: 0.5785
-        self.assertEqual(0.7800, round(auc_results['max'], 4))  # MATLAB: 0.8033
+        self.assertEqual(0.0330, round(auc_results['p_value'], 4))  
+        self.assertEqual(0.5785, round(auc_results['mean'], 4))  
+        self.assertEqual(0.8033, round(auc_results['max'], 4))  
         self.assertEqual(0.5000, round(auc_results['min'], 4))
-        self.assertEqual(0.0570, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.0587
-        self.assertEqual(0.0018, round(auc_results['standard_error'], 4))  # MATLAB: 0.0019
+        self.assertEqual(0.0586, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.0587
+        self.assertEqual(0.0019, round(auc_results['standard_error'], 4))  
 
         aupr_results = permutations['aupr']
-        self.assertEqual(0.5421, round(aupr_results['original_value'], 4))
-        self.assertEqual(0.3077, round(aupr_results['p_value'], 4))  # MATLAB: 0.3397
-        self.assertEqual(0.5119, round(aupr_results['mean'], 4))  # MATLAB: 0.5152
-        self.assertEqual(0.7811, round(aupr_results['max'], 4))  # MATLAB: 0.8251
-        self.assertEqual(0.3867, round(aupr_results['min'], 4))  # MATLAB: 0.3882
-        self.assertEqual(0.0726, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.0753
-        self.assertEqual(0.0023, round(aupr_results['standard_error'], 4))  # MATLAB: 0.0024
+        self.assertEqual(0.531, round(aupr_results['original_value'], 4))  # MATLAB: 0.5421
+        self.assertEqual(0.3806, round(aupr_results['p_value'], 4))  # MATLAB: 0.3397
+        self.assertEqual(0.515, round(aupr_results['mean'], 4))  # MATLAB: 0.5152
+        self.assertEqual(0.8251, round(aupr_results['max'], 4))  
+        self.assertEqual(0.3882, round(aupr_results['min'], 4))  
+        self.assertEqual(0.076, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.0753
+        self.assertEqual(0.0024, round(aupr_results['standard_error'], 4))  
 
         mcc_results = permutations['mcc']
         self.assertEqual(0.1833, round(mcc_results['original_value'], 4))
-        self.assertEqual(0.4476, round(mcc_results['p_value'], 4))  # MATLAB: 0.4535
-        self.assertEqual(0.1262, round(mcc_results['mean'], 4))  # MATLAB: 0.1269
-        self.assertEqual(0.5333, round(mcc_results['max'], 4))  # MATLAB: 0.6500
+        self.assertEqual(0.4535, round(mcc_results['p_value'], 4))  
+        self.assertEqual(0.1269, round(mcc_results['mean'], 4))  
+        self.assertEqual(0.65, round(mcc_results['max'], 4))  
         self.assertEqual(-0.1667, round(mcc_results['min'], 4))
-        self.assertEqual(0.1145, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.1153
+        self.assertEqual(0.1152, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.1153
         self.assertEqual(0.0036, round(mcc_results['standard_error'], 4))
 
     def test_ldps_returns_expected_indices_when_circles_data_without_permutations(self):
@@ -77,30 +77,30 @@ class TestLDPSCommunitySeparability(unittest.TestCase):
 
         auc_results = permutations['auc']
         self.assertEqual(0.5100, round(auc_results['original_value'], 4))
-        self.assertEqual(0.9251, round(auc_results['p_value'], 4))  # MATLAB: 0.9131
-        self.assertEqual(0.5730, round(auc_results['mean'], 4))  # MATLAB: 0.5712
-        self.assertEqual(0.8062, round(auc_results['max'], 4))  # MATLAB: 0.8325
+        self.assertEqual(0.9131, round(auc_results['p_value'], 4))  
+        self.assertEqual(0.5712, round(auc_results['mean'], 4))  
+        self.assertEqual(0.8325, round(auc_results['max'], 4))  
         self.assertEqual(0.5000, round(auc_results['min'], 4))
-        self.assertEqual(0.0548, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.0526
+        self.assertEqual(0.0526, round(auc_results['standard_deviation'], 4))  
         self.assertEqual(0.0017, round(auc_results['standard_error'], 4))
 
         aupr_results = permutations['aupr']
         self.assertEqual(0.6425, round(aupr_results['original_value'], 4))
-        self.assertEqual(0.1578, round(aupr_results['p_value'], 4))  # MATLAB: 0.1249
-        self.assertEqual(0.5788, round(aupr_results['mean'], 4))  # MATLAB: 0.5692
-        self.assertEqual(0.8237, round(aupr_results['max'], 4))  # MATLAB: 0.8109
-        self.assertEqual(0.4577, round(aupr_results['min'], 4))  # MATLAB: 0.4613
+        self.assertEqual(0.1249, round(aupr_results['p_value'], 4))  
+        self.assertEqual(0.5692, round(aupr_results['mean'], 4))  
+        self.assertEqual(0.8109, round(aupr_results['max'], 4))  
+        self.assertEqual(0.4613, round(aupr_results['min'], 4))  
         self.assertEqual(0.0625, round(aupr_results['standard_deviation'], 4))
         self.assertEqual(0.0020, round(aupr_results['standard_error'], 4))
 
         mcc_results = permutations['mcc']
         self.assertEqual(0.0000, round(mcc_results['original_value'], 4))
         self.assertEqual(1.0000, round(mcc_results['p_value'], 4))
-        self.assertEqual(0.1222, round(mcc_results['mean'], 4))  # MATLAB: 0.1195
-        self.assertEqual(0.5000, round(mcc_results['max'], 4))  # MATLAB: 0.6000
+        self.assertEqual(0.1195, round(mcc_results['mean'], 4))  
+        self.assertEqual(0.6000, round(mcc_results['max'], 4))  
         self.assertEqual(0.0000, round(mcc_results['min'], 4))
-        self.assertEqual(0.1003, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.0948
-        self.assertEqual(0.0032, round(mcc_results['standard_error'], 4))  # MATLAB: 0.0030
+        self.assertEqual(0.0947, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.0948
+        self.assertEqual(0.0030, round(mcc_results['standard_error'], 4))  
 
     def test_ldps_returns_expected_indices_when_rhombus_data_without_permutations(self):
         embedding, communities = _rhombus()
@@ -126,28 +126,28 @@ class TestLDPSCommunitySeparability(unittest.TestCase):
         auc_results = permutations['auc']
         self.assertEqual(1.0000, round(auc_results['original_value'], 4))
         self.assertEqual(0.0010, round(auc_results['p_value'], 4))
-        self.assertEqual(0.6056, round(auc_results['mean'], 4))  # MATLAB: 0.6047
-        self.assertEqual(0.8850, round(auc_results['max'], 4))  # MATLAB: 0.9250
+        self.assertEqual(0.6048, round(auc_results['mean'], 4))  # MATLAB: 0.6047
+        self.assertEqual(0.9250, round(auc_results['max'], 4))  
         self.assertEqual(0.5000, round(auc_results['min'], 4))
-        self.assertEqual(0.0750, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.0796
-        self.assertEqual(0.0024, round(auc_results['standard_error'], 4))  # MATLAB: 0.0025
+        self.assertEqual(0.0796, round(auc_results['standard_deviation'], 4))  
+        self.assertEqual(0.0025, round(auc_results['standard_error'], 4))  
 
         aupr_results = permutations['aupr']
         self.assertEqual(1.0000, round(aupr_results['original_value'], 4))
         self.assertEqual(0.0010, round(aupr_results['p_value'], 4))
-        self.assertEqual(0.6098, round(aupr_results['mean'], 4))  # MATLAB: 0.6120
+        self.assertEqual(0.6120, round(aupr_results['mean'], 4))  
         self.assertEqual(0.9137, round(aupr_results['max'], 4))
-        self.assertEqual(0.4401, round(aupr_results['min'], 4))  # MATLAB: 0.4350
-        self.assertEqual(0.0977, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.1008
-        self.assertEqual(0.0031, round(aupr_results['standard_error'], 4))  # MATLAB: 0.0032
+        self.assertEqual(0.4350, round(aupr_results['min'], 4))  
+        self.assertEqual(0.1008, round(aupr_results['standard_deviation'], 4))  
+        self.assertEqual(0.0032, round(aupr_results['standard_error'], 4))  
 
         mcc_results = permutations['mcc']
         self.assertEqual(1.0000, round(mcc_results['original_value'], 4))
         self.assertEqual(0.0010, round(mcc_results['p_value'], 4))
-        self.assertEqual(0.1688, round(mcc_results['mean'], 4))  # MATLAB: 0.1646
-        self.assertEqual(0.6000, round(mcc_results['max'], 4))  # MATLAB: 0.8000
+        self.assertEqual(0.1646, round(mcc_results['mean'], 4))  
+        self.assertEqual(0.8000, round(mcc_results['max'], 4))  
         self.assertEqual(0.0000, round(mcc_results['min'], 4))
-        self.assertEqual(0.1512, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.1526
+        self.assertEqual(0.1525, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.1526
         self.assertEqual(0.0048, round(mcc_results['standard_error'], 4))
 
     def test_ldps_returns_expected_indices_when_spirals_data_without_permutations(self):
@@ -173,30 +173,30 @@ class TestLDPSCommunitySeparability(unittest.TestCase):
 
         auc_results = permutations['auc']
         self.assertEqual(0.6128, round(auc_results['original_value'], 4))
-        self.assertEqual(0.1738, round(auc_results['p_value'], 4))
-        self.assertEqual(0.5642, round(auc_results['mean'], 4))  # MATLAB: 0.5645
-        self.assertEqual(0.7446, round(auc_results['max'], 4))  # MATLAB: 0.7745
+        self.assertEqual(0.1748, round(auc_results['p_value'], 4))  # MATLAB: 0.1738
+        self.assertEqual(0.5645, round(auc_results['mean'], 4))  
+        self.assertEqual(0.7745, round(auc_results['max'], 4))  
         self.assertEqual(0.5000, round(auc_results['min'], 4))
-        self.assertEqual(0.0486, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.0499
-        self.assertEqual(0.0015, round(auc_results['standard_error'], 4))  # MATLAB: 0.0016
+        self.assertEqual(0.0499, round(auc_results['standard_deviation'], 4))  
+        self.assertEqual(0.0016, round(auc_results['standard_error'], 4))  
 
         aupr_results = permutations['aupr']
         self.assertEqual(0.6192, round(aupr_results['original_value'], 4))
-        self.assertEqual(0.0290, round(aupr_results['p_value'], 4))  # MATLAB: 0.0370
-        self.assertEqual(0.4848, round(aupr_results['mean'], 4))  # MATLAB: 0.4868
-        self.assertEqual(0.7352, round(aupr_results['max'], 4))  # MATLAB: 0.7580
-        self.assertEqual(0.3812, round(aupr_results['min'], 4))  # MATLAB: 0.3797
-        self.assertEqual(0.0606, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.0627
-        self.assertEqual(0.0019, round(aupr_results['standard_error'], 4))
+        self.assertEqual(0.0370, round(aupr_results['p_value'], 4))  
+        self.assertEqual(0.4867, round(aupr_results['mean'], 4))  # MATLAB: 0.4868
+        self.assertEqual(0.7580, round(aupr_results['max'], 4))  
+        self.assertEqual(0.3797, round(aupr_results['min'], 4))  
+        self.assertEqual(0.0627, round(aupr_results['standard_deviation'], 4))  
+        self.assertEqual(0.0020, round(aupr_results['standard_error'], 4))  
 
         mcc_results = permutations['mcc']
         self.assertEqual(0.1780, round(mcc_results['original_value'], 4))
-        self.assertEqual(0.3207, round(mcc_results['p_value'], 4))  # MATLAB: 0.3117
-        self.assertEqual(0.1066, round(mcc_results['mean'], 4))  # MATLAB: 0.1033
+        self.assertEqual(0.3117, round(mcc_results['p_value'], 4))  
+        self.assertEqual(0.1033, round(mcc_results['mean'], 4))  
         self.assertEqual(0.4022, round(mcc_results['max'], 4))
         self.assertEqual(-0.1209, round(mcc_results['min'], 4))
-        self.assertEqual(0.0948, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.0923
-        self.assertEqual(0.0030, round(mcc_results['standard_error'], 4))  # MATLAB: 0.0029
+        self.assertEqual(0.0923, round(mcc_results['standard_deviation'], 4))  
+        self.assertEqual(0.0029, round(mcc_results['standard_error'], 4))  
 
     def test_ldps_returns_expected_indices_when_parallel_lines_data_without_permutations(self):
         embedding, communities = _parallel_lines()
@@ -221,27 +221,27 @@ class TestLDPSCommunitySeparability(unittest.TestCase):
 
         auc_results = permutations['auc']
         self.assertEqual(0.5833, round(auc_results['original_value'], 4))  # MATLAB: 1.0000
-        self.assertEqual(0.6973, round(auc_results['p_value'], 4))  # MATLAB: 0.0020
-        self.assertEqual(0.6398, round(auc_results['mean'], 4))  # MATLAB: 0.6349
+        self.assertEqual(0.6863, round(auc_results['p_value'], 4))  # MATLAB: 0.0020
+        self.assertEqual(0.6336, round(auc_results['mean'], 4))  # MATLAB: 0.6349
         self.assertEqual(1.0000, round(auc_results['max'], 4))
         self.assertEqual(0.5000, round(auc_results['min'], 4))
-        self.assertEqual(0.1022, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.0981
+        self.assertEqual(0.1, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.0981
         self.assertEqual(0.0032, round(auc_results['standard_error'], 4))  # MATLAB: 0.0031
 
         aupr_results = permutations['aupr']
         self.assertEqual(0.6199, round(aupr_results['original_value'], 4))  # MATLAB: 1.0000
-        self.assertEqual(0.5934, round(aupr_results['p_value'], 4))  # MATLAB: 0.0020
-        self.assertEqual(0.6555, round(aupr_results['mean'], 4))  # MATLAB: 0.6504
+        self.assertEqual(0.5694, round(aupr_results['p_value'], 4))  # MATLAB: 0.0020
+        self.assertEqual(0.6494, round(aupr_results['mean'], 4))  # MATLAB: 0.6504
         self.assertEqual(1.0000, round(aupr_results['max'], 4))
         self.assertEqual(0.4444, round(aupr_results['min'], 4))  # MATLAB: 0.4422
-        self.assertEqual(0.1223, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.1193
-        self.assertEqual(0.0039, round(aupr_results['standard_error'], 4))  # MATLAB: 0.0038
+        self.assertEqual(0.1207, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.1193
+        self.assertEqual(0.0038, round(aupr_results['standard_error'], 4))  
 
         mcc_results = permutations['mcc']
         self.assertEqual(0.0000, round(mcc_results['original_value'], 4))  # MATLAB: 1.0000
         self.assertEqual(1.0000, round(mcc_results['p_value'], 4))  # MATLAB: 0.0020
-        self.assertEqual(0.2127, round(mcc_results['mean'], 4))  # MATLAB: 0.2107
+        self.assertEqual(0.205, round(mcc_results['mean'], 4))  # MATLAB: 0.2107
         self.assertEqual(1.0000, round(mcc_results['max'], 4))
         self.assertEqual(0.0000, round(mcc_results['min'], 4))
-        self.assertEqual(0.2079, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.2052
+        self.assertEqual(0.2073, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.2052
         self.assertEqual(0.0066, round(mcc_results['standard_error'], 4))  # MATLAB: 0.0065

--- a/tests/test_tsps_community_separability.py
+++ b/tests/test_tsps_community_separability.py
@@ -30,8 +30,8 @@ class TestTSPSCommunitySeparability(unittest.TestCase):
         auc_results = permutations['auc']
         self.assertEqual(1.0000, round(auc_results['original_value'], 4))
         self.assertEqual(0.0010, round(auc_results['p_value'], 4))
-        self.assertEqual(0.5806, round(auc_results['mean'], 4))  # MATLAB: 0.5813
-        self.assertEqual(0.8367, round(auc_results['max'], 4))  # MATLAB: 0.8300
+        self.assertEqual(0.5813, round(auc_results['mean'], 4))  
+        self.assertEqual(0.8300, round(auc_results['max'], 4))  
         self.assertEqual(0.5000, round(auc_results['min'], 4))
         self.assertEqual(0.0599, round(auc_results['standard_deviation'], 4))
         self.assertEqual(0.0019, round(auc_results['standard_error'], 4))
@@ -39,20 +39,20 @@ class TestTSPSCommunitySeparability(unittest.TestCase):
         aupr_results = permutations['aupr']
         self.assertEqual(1.0000, round(aupr_results['original_value'], 4))
         self.assertEqual(0.0010, round(aupr_results['p_value'], 4))
-        self.assertEqual(0.5164, round(aupr_results['mean'], 4))  # MATLAB: 0.5160
-        self.assertEqual(0.8367, round(aupr_results['max'], 4))  # MATLAB: 0.8032
-        self.assertEqual(0.3923, round(aupr_results['min'], 4))  # MATLAB: 0.3884
-        self.assertEqual(0.0755, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.0759
+        self.assertEqual(0.5160, round(aupr_results['mean'], 4))  
+        self.assertEqual(0.8032, round(aupr_results['max'], 4))  
+        self.assertEqual(0.3884, round(aupr_results['min'], 4))  
+        self.assertEqual(0.076, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.0759
         self.assertEqual(0.0024, round(aupr_results['standard_error'], 4))
 
         mcc_results = permutations['mcc']
         self.assertEqual(1.0000, round(mcc_results['original_value'], 4))
         self.assertEqual(0.0010, round(mcc_results['p_value'], 4))
-        self.assertEqual(0.1298, round(mcc_results['mean'], 4))  # MATLAB: 0.1283
+        self.assertEqual(0.1283, round(mcc_results['mean'], 4))  
         self.assertEqual(0.6500, round(mcc_results['max'], 4))
         self.assertEqual(-0.1667, round(mcc_results['min'], 4))
-        self.assertEqual(0.1159, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.1201
-        self.assertEqual(0.0037, round(mcc_results['standard_error'], 4))  # MATLAB: 0.0038
+        self.assertEqual(0.1201, round(mcc_results['standard_deviation'], 4))  
+        self.assertEqual(0.0038, round(mcc_results['standard_error'], 4))  
 
     def test_tsps_returns_expected_indices_when_circles_data_without_permutations(self):
         embedding, communities = _circles()
@@ -78,28 +78,28 @@ class TestTSPSCommunitySeparability(unittest.TestCase):
         auc_results = permutations['auc']
         self.assertEqual(1.0000, round(auc_results['original_value'], 4))
         self.assertEqual(0.0010, round(auc_results['p_value'], 4))
-        self.assertEqual(0.5745, round(auc_results['mean'], 4))  # MATLAB: 0.5781
-        self.assertEqual(0.8075, round(auc_results['max'], 4))  # MATLAB: 0.7850
+        self.assertEqual(0.5781, round(auc_results['mean'], 4))  
+        self.assertEqual(0.7850, round(auc_results['max'], 4))  
         self.assertEqual(0.5000, round(auc_results['min'], 4))
-        self.assertEqual(0.0552, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.0569
-        self.assertEqual(0.0017, round(auc_results['standard_error'], 4))  # MATLAB: 0.0018
+        self.assertEqual(0.0569, round(auc_results['standard_deviation'], 4))  
+        self.assertEqual(0.0018, round(auc_results['standard_error'], 4))  
 
         aupr_results = permutations['aupr']
         self.assertEqual(1.0000, round(aupr_results['original_value'], 4))
         self.assertEqual(0.0010, round(aupr_results['p_value'], 4))
-        self.assertEqual(0.5772, round(aupr_results['mean'], 4))  # MATLAB: 0.5822
-        self.assertEqual(0.8483, round(aupr_results['max'], 4))  # MATLAB: 0.8092
-        self.assertEqual(0.4567, round(aupr_results['min'], 4))  # MATLAB: 0.4557
-        self.assertEqual(0.0655, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.0679
+        self.assertEqual(0.5824, round(aupr_results['mean'], 4))  # MATLAB: 0.5822
+        self.assertEqual(0.8092, round(aupr_results['max'], 4))  
+        self.assertEqual(0.4563, round(aupr_results['min'], 4))  # MATLAB: 0.4557
+        self.assertEqual(0.0677, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.0679
         self.assertEqual(0.0021, round(aupr_results['standard_error'], 4))
 
         mcc_results = permutations['mcc']
         self.assertEqual(1.0000, round(mcc_results['original_value'], 4))
         self.assertEqual(0.0010, round(mcc_results['p_value'], 4))
-        self.assertEqual(0.1246, round(mcc_results['mean'], 4))  # MATLAB: 0.1284
+        self.assertEqual(0.1284, round(mcc_results['mean'], 4))  
         self.assertEqual(0.5000, round(mcc_results['max'], 4))
         self.assertEqual(0.0000, round(mcc_results['min'], 4))
-        self.assertEqual(0.1044, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.1057
+        self.assertEqual(0.1056, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.1057
         self.assertEqual(0.0033, round(mcc_results['standard_error'], 4))
 
     def test_tsps_returns_expected_indices_when_rhombus_data_without_permutations(self):
@@ -126,28 +126,28 @@ class TestTSPSCommunitySeparability(unittest.TestCase):
         auc_results = permutations['auc']
         self.assertEqual(0.9100, round(auc_results['original_value'], 4))
         self.assertEqual(0.0030, round(auc_results['p_value'], 4))
-        self.assertEqual(0.6065, round(auc_results['mean'], 4))  # MATLAB: 0.6083
-        self.assertEqual(0.9800, round(auc_results['max'], 4))  # MATLAB: 0.9500
+        self.assertEqual(0.6083, round(auc_results['mean'], 4))  
+        self.assertEqual(0.9500, round(auc_results['max'], 4))  
         self.assertEqual(0.5000, round(auc_results['min'], 4))
-        self.assertEqual(0.0797, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.0801
+        self.assertEqual(0.0801, round(auc_results['standard_deviation'], 4))  
         self.assertEqual(0.0025, round(auc_results['standard_error'], 4))
 
         aupr_results = permutations['aupr']
         self.assertEqual(0.9212, round(aupr_results['original_value'], 4))
         self.assertEqual(0.0020, round(aupr_results['p_value'], 4))
-        self.assertEqual(0.6132, round(aupr_results['mean'], 4))  # MATLAB: 0.6149
-        self.assertEqual(0.9826, round(aupr_results['max'], 4))  # MATLAB: 0.9569
-        self.assertEqual(0.4491, round(aupr_results['min'], 4))  # MATLAB: 0.4505
-        self.assertEqual(0.0935, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.0949
+        self.assertEqual(0.615, round(aupr_results['mean'], 4))  # MATLAB: 0.6149
+        self.assertEqual(0.9569, round(aupr_results['max'], 4))  
+        self.assertEqual(0.4505, round(aupr_results['min'], 4))  
+        self.assertEqual(0.0948, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.0949
         self.assertEqual(0.0030, round(aupr_results['standard_error'], 4))
 
         mcc_results = permutations['mcc']
         self.assertEqual(0.4000, round(mcc_results['original_value'], 4))
-        self.assertEqual(0.1768, round(mcc_results['p_value'], 4))  # MATLAB: 0.2008
-        self.assertEqual(0.1716, round(mcc_results['mean'], 4))  # MATLAB: 0.1830
+        self.assertEqual(0.2008, round(mcc_results['p_value'], 4))  
+        self.assertEqual(0.1830, round(mcc_results['mean'], 4))  
         self.assertEqual(0.8000, round(mcc_results['max'], 4))
         self.assertEqual(0.0000, round(mcc_results['min'], 4))
-        self.assertEqual(0.1523, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.1534
+        self.assertEqual(0.1533, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.1534
         self.assertEqual(0.0048, round(mcc_results['standard_error'], 4))  # MATLAB: 0.0049
 
     def test_tsps_returns_expected_indices_when_spirals_data_without_permutations(self):
@@ -174,29 +174,29 @@ class TestTSPSCommunitySeparability(unittest.TestCase):
         auc_results = permutations['auc']
         self.assertEqual(0.8614, round(auc_results['original_value'], 4))
         self.assertEqual(0.0010, round(auc_results['p_value'], 4))
-        self.assertEqual(0.5637, round(auc_results['mean'], 4))  # MATLAB: 0.5603
-        self.assertEqual(0.7622, round(auc_results['max'], 4))  # MATLAB: 0.7391
+        self.assertEqual(0.5603, round(auc_results['mean'], 4))  
+        self.assertEqual(0.7391, round(auc_results['max'], 4))  
         self.assertEqual(0.5000, round(auc_results['min'], 4))
-        self.assertEqual(0.0473, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.0453
-        self.assertEqual(0.0015, round(auc_results['standard_error'], 4))  # MATLAB: 0.0014
+        self.assertEqual(0.0453, round(auc_results['standard_deviation'], 4))  
+        self.assertEqual(0.0014, round(auc_results['standard_error'], 4))  
 
         aupr_results = permutations['aupr']
         self.assertEqual(0.8446, round(aupr_results['original_value'], 4))
         self.assertEqual(0.0010, round(aupr_results['p_value'], 4))
-        self.assertEqual(0.4859, round(aupr_results['mean'], 4))  # MATLAB: 0.4843
-        self.assertEqual(0.7051, round(aupr_results['max'], 4))  # MATLAB: 0.7469
-        self.assertEqual(0.3842, round(aupr_results['min'], 4))  # MATLAB: 0.3863
-        self.assertEqual(0.0592, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.0590
+        self.assertEqual(0.4844, round(aupr_results['mean'], 4))  
+        self.assertEqual(0.7469, round(aupr_results['max'], 4))  
+        self.assertEqual(0.3863, round(aupr_results['min'], 4))  
+        self.assertEqual(0.0589, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.0590
         self.assertEqual(0.0019, round(aupr_results['standard_error'], 4))
 
         mcc_results = permutations['mcc']
         self.assertEqual(0.5516, round(mcc_results['original_value'], 4))
         self.assertEqual(0.0010, round(mcc_results['p_value'], 4))
-        self.assertEqual(0.0994, round(mcc_results['mean'], 4))  # MATLAB: 0.0948
-        self.assertEqual(0.4022, round(mcc_results['max'], 4))  # MATLAB: 0.4769
+        self.assertEqual(0.0948, round(mcc_results['mean'], 4))  
+        self.assertEqual(0.4769, round(mcc_results['max'], 4))  
         self.assertEqual(-0.1209, round(mcc_results['min'], 4))
-        self.assertEqual(0.0956, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.0877
-        self.assertEqual(0.0030, round(mcc_results['standard_error'], 4))  # MATLAB: 0.0028
+        self.assertEqual(0.0877, round(mcc_results['standard_deviation'], 4))  
+        self.assertEqual(0.0028, round(mcc_results['standard_error'], 4))  
 
     def test_tsps_returns_expected_indices_when_parallel_lines_data_without_permutations(self):
         embedding, communities = _parallel_lines()
@@ -221,27 +221,27 @@ class TestTSPSCommunitySeparability(unittest.TestCase):
 
         auc_results = permutations['auc']
         self.assertEqual(1.0000, round(auc_results['original_value'], 4))
-        self.assertEqual(0.0050, round(auc_results['p_value'], 4))  # MATLAB: 0.0020
-        self.assertEqual(0.6414, round(auc_results['mean'], 4))  # MATLAB: 0.6358
+        self.assertEqual(0.0020, round(auc_results['p_value'], 4))  
+        self.assertEqual(0.6358, round(auc_results['mean'], 4))  
         self.assertEqual(1.0000, round(auc_results['max'], 4))
         self.assertEqual(0.5000, round(auc_results['min'], 4))
-        self.assertEqual(0.1018, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.1006
+        self.assertEqual(0.1005, round(auc_results['standard_deviation'], 4))  # MATLAB: 0.1006
         self.assertEqual(0.0032, round(auc_results['standard_error'], 4))
 
         aupr_results = permutations['aupr']
         self.assertEqual(1.0000, round(aupr_results['original_value'], 4))
-        self.assertEqual(0.0050, round(aupr_results['p_value'], 4))  # MATLAB: 0.0020
-        self.assertEqual(0.6630, round(aupr_results['mean'], 4))  # MATLAB: 0.6503
+        self.assertEqual(0.0020, round(aupr_results['p_value'], 4))  
+        self.assertEqual(0.6501, round(aupr_results['mean'], 4))  # MATLAB: 0.6503
         self.assertEqual(1.0000, round(aupr_results['max'], 4))
         self.assertEqual(0.4422, round(aupr_results['min'], 4))
-        self.assertEqual(0.1205, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.1203
+        self.assertEqual(0.1204, round(aupr_results['standard_deviation'], 4))  # MATLAB: 0.1203
         self.assertEqual(0.0038, round(aupr_results['standard_error'], 4))
 
         mcc_results = permutations['mcc']
         self.assertEqual(1.0000, round(mcc_results['original_value'], 4))
-        self.assertEqual(0.0050, round(mcc_results['p_value'], 4))  # MATLAB: 0.0020
-        self.assertEqual(0.2150, round(mcc_results['mean'], 4))  # MATLAB: 0.2107
+        self.assertEqual(0.0020, round(mcc_results['p_value'], 4))  
+        self.assertEqual(0.2107, round(mcc_results['mean'], 4))  
         self.assertEqual(1.0000, round(mcc_results['max'], 4))
         self.assertEqual(0.0000, round(mcc_results['min'], 4))
-        self.assertEqual(0.2116, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.2052
-        self.assertEqual(0.0067, round(mcc_results['standard_error'], 4))  # MATLAB: 0.0065
+        self.assertEqual(0.2051, round(mcc_results['standard_deviation'], 4))  # MATLAB: 0.2052
+        self.assertEqual(0.0065, round(mcc_results['standard_error'], 4))  


### PR DESCRIPTION
    1) changed the computing of projection from using a loop to using matrix multiplication.
    2) changed conditional setting in aupr evaluation to equal the Matlab code.
    3) changed the way to generate random permutation indices to match the Matlab code.
    4) add a parameter to run concorde on different machine platforms.